### PR TITLE
v0.2.5: add registration object

### DIFF
--- a/__tests__/registration.test.ts
+++ b/__tests__/registration.test.ts
@@ -1,0 +1,58 @@
+import {
+  InternalRegistration,
+} from '../src/types';
+
+// Mock params.
+import signatureExample from './data/signature_example.json';
+import Registration from '../src/registrations';
+
+const partialRegistration: Partial<InternalRegistration> = {
+  ethereumAddress: 'address',
+};
+
+describe('Registration', () => {
+  describe('sign()', () => {
+
+    it('signs and verifies a registration', () => {
+      const registration: InternalRegistration = {
+        ...partialRegistration,
+        publicKey: signatureExample.keyPair.publicKey,
+      } as InternalRegistration;
+      const signature: string = Registration.fromInternal(
+        registration,
+      ).sign(signatureExample.keyPair.privateKey);
+      const verification: boolean = Registration.fromInternal(
+        registration,
+      ).verifySignature(signature);
+      expect(verification).toEqual(true);
+    });
+
+    it('signs and verifies an registration (even y) ', () => {
+      const registration: InternalRegistration = {
+        ...partialRegistration,
+        publicKey: signatureExample.keyPairEvenY.publicKey,
+      } as InternalRegistration;
+      const signature: string = Registration.fromInternal(
+        registration,
+      ).sign(signatureExample.keyPairEvenY.privateKey);
+      const verification: boolean = Registration.fromInternal(
+        registration,
+      ).verifySignature(signature);
+      expect(verification).toEqual(true);
+    });
+
+    it('signs and cannot verify an registration with another public key', () => {
+      const registration: InternalRegistration = {
+        ...partialRegistration,
+        publicKey: signatureExample.keyPair.publicKey,
+      } as InternalRegistration;
+      const signature: string = Registration.fromInternal(
+        registration,
+      ).sign(signatureExample.keyPairEvenY.privateKey);
+      const verification: boolean = Registration.fromInternal(
+        registration,
+      ).verifySignature(signature);
+      expect(verification).toEqual(false);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/registrations.ts
+++ b/src/registrations.ts
@@ -1,0 +1,23 @@
+import nodeCrypto from 'crypto';
+
+import Signable from './signable';
+import { InternalRegistration } from './types';
+
+/**
+ * Wrapper object to convert, hash, sign, or verify the signature of a registration.
+ */
+export default class Registration extends Signable<InternalRegistration> {
+
+  static fromInternal(
+    internalRegistration: InternalRegistration,
+  ): Registration {
+    return new Registration(internalRegistration);
+  }
+
+  protected calculateHash(): string {
+    const registration = this.starkwareObject;
+
+    const message = registration.ethereumAddress + registration.publicKey;
+    return nodeCrypto.createHmac('sha256', '').update(message).digest('hex');
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,11 @@ export interface InternalApiRequest {
   publicKey: string,
 }
 
+export interface InternalRegistration {
+  ethereumAddress: string,
+  publicKey: string,
+}
+
 export interface StarkwareSignable {
   publicKey: string;
 }


### PR DESCRIPTION
- Currently very similar to the api-request object but making it distinct gives us flexibility to modify it in the future