### PR TITLE
v0.7.0 Take limit fee as a fraction

### DIFF
--- a/__tests__/helpers/assets.test.ts
+++ b/__tests__/helpers/assets.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   fromQuantums,
   getStarkwareAmounts,
+  getStarkwareLimitFeeAmount,
   toQuantumsExact,
   toQuantumsRoundDown,
   toQuantumsRoundUp,
@@ -141,6 +142,18 @@ describe('assets helpers', () => {
       expect(
         toQuantumsRoundUp('12.00000031', DydxAsset.LINK),
       ).toBe('120000004');
+    });
+  });
+
+  describe('getStarkwareLimitFeeAmount()', () => {
+
+    it('converts the order limit fee as expected (edge case)', () => {
+      expect(
+        getStarkwareLimitFeeAmount(
+          '0.000001999999999999999999999999999999999999999999',
+          '50750272151',
+        ),
+      ).toBe('50751');
     });
   });
 });

--- a/__tests__/signable/order.test.ts
+++ b/__tests__/signable/order.test.ts
@@ -33,7 +33,7 @@ const mockKeyPairEvenY: KeyPair = {
 const mockOrder: OrderWithClientId = {
   positionId: '12345',
   humanSize: '145.0005',
-  humanLimitFee: '0.032985',
+  limitFee: '0.125',
   market: DydxMarket.ETH_USD,
   side: StarkwareOrderSide.BUY,
   expirationIsoTimestamp: '2020-09-17T04:15:55.028Z',
@@ -41,12 +41,12 @@ const mockOrder: OrderWithClientId = {
   clientId: 'This is an ID that the client came up with to describe this order',
 };
 const mockSignature = (
-  '01ac25fb542c7f58953cbbaec0bd774e480d6e22d7c7145f531986c32ce28e09' +
-  '0038738abd1a7a960a45376c926fc7e41889d0f365c8749a80306e355dcf78ec'
+  '059487ea7c537f34516f4dc7c54ad30ab0096823269ba18aea0e64e13fb03462' +
+  '03be73ed4dafbf99baeeaee6dce315cd834b5e3257d4e74371d14cf8f2189a59'
 );
 const mockSignatureEvenY = (
-  '05de75d37686126262e31560aca7e3e3782210d1ed5395b8c8704b1a51831a7a' +
-  '01427d9b50773cd537e357c969aeb8dc24e23365418b641a11b5902d1140b8de'
+  '030644ef5b2de9e93f13df5a4cf8284e7256223366b5da29bf2002ed40825171' +
+  '03961ec47c34c49e97095c546895cc22afa6e563474615729720fd8b768c5b87'
 );
 
 describe('SignableOrder', () => {
@@ -174,7 +174,7 @@ describe('SignableOrder', () => {
         .toStarkware();
       expect(starkwareOrder.quantumsAmountSynthetic).toEqual('14500050000');
       expect(starkwareOrder.quantumsAmountCollateral).toEqual('50750272151');
-      expect(starkwareOrder.quantumsAmountFee).toEqual('32985');
+      expect(starkwareOrder.quantumsAmountFee).toEqual('6343784019');
     });
 
     it('throws if the market is unknown', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,8 +28,6 @@ export const SIGNED_ASSET_ID_MAP: Record<DydxMarket, string> = {
 
 /**
  * The smallest unit of the asset in the Starkware system, represented in canonical (human) units.
- *
- * TODO: Update these after hearing back from Starkware.
  */
 export const ASSET_QUANTUM_SIZE: Record<DydxAsset, string> = {
   [DydxAsset.USDC]: '1e-6',

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -141,3 +141,18 @@ export function getStarkwareAmounts(
     isBuyingSynthetic,
   };
 }
+
+/**
+ * Convert a limit fee fraction for an order into a collateral quantums amount.
+ */
+export function getStarkwareLimitFeeAmount(
+  limitFee: string,
+  quantumsAmountCollateral: string,
+): string {
+  // Constrain the limit fee to six decimals of precision. The final fee amount must be rounded up.
+  return new Big(limitFee)
+    .round(6, RoundingMode.RoundDown)
+    .times(quantumsAmountCollateral)
+    .round(0, RoundingMode.RoundUp)
+    .toFixed(0);
+}

--- a/src/signable/order.ts
+++ b/src/signable/order.ts
@@ -8,7 +8,7 @@ import {
   getStarkwareAmounts,
   isoTimestampToEpochSeconds,
   nonceFromClientId,
-  toQuantumsExact,
+  getStarkwareLimitFeeAmount,
 } from '../helpers';
 import { pedersen } from '../lib/starkex-resources';
 import { decToBn, hexToBn } from '../lib/util';
@@ -66,8 +66,8 @@ export class SignableOrder extends StarkSignable<StarkwareOrder> {
       isBuyingSynthetic,
     } = getStarkwareAmounts(order);
 
-    // The humanLimitFee is a fraction, e.g. 0.01 is a 1% fee. It is paid in the collateral asset.
-    const quantumsAmountFee = toQuantumsExact(order.humanLimitFee, COLLATERAL_ASSET);
+    // The limitFee is a fraction, e.g. 0.01 is a 1% fee. It is always paid in the collateral asset.
+    const quantumsAmountFee = getStarkwareLimitFeeAmount(order.limitFee, quantumsAmountCollateral);
     const assetIdFee = ASSET_ID_MAP[COLLATERAL_ASSET];
 
     // Convert to a Unix timestamp (in seconds).

--- a/src/signable/order.ts
+++ b/src/signable/order.ts
@@ -66,7 +66,7 @@ export class SignableOrder extends StarkSignable<StarkwareOrder> {
       isBuyingSynthetic,
     } = getStarkwareAmounts(order);
 
-    // The fee is an amount, not a percentage, and is always denominated in the collateral asset.
+    // The humanLimitFee is a fraction, e.g. 0.01 is a 1% fee. It is paid in the collateral asset.
     const quantumsAmountFee = toQuantumsExact(order.humanLimitFee, COLLATERAL_ASSET);
     const assetIdFee = ASSET_ID_MAP[COLLATERAL_ASSET];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface StarkwareConditionalTransfer {
 interface OrderParamsBase {
   positionId: string;
   humanSize: string;
-  humanLimitFee: string; // Fee fraction, e.g. 0.01 is a 1% fee.
+  limitFee: string; // Max fee fraction, e.g. 0.01 is a max 1% fee.
   market: DydxMarket;
   side: StarkwareOrderSide;
   expirationIsoTimestamp: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface StarkwareConditionalTransfer {
 interface OrderParamsBase {
   positionId: string;
   humanSize: string;
-  humanLimitFee: string;
+  humanLimitFee: string; // Fee fraction, e.g. 0.01 is a 1% fee.
   market: DydxMarket;
   side: StarkwareOrderSide;
   expirationIsoTimestamp: string;


### PR DESCRIPTION
Limit fee is taken to be a fraction and processed as follows to get the fee amount:
* Limit precision to 6 decimals (rounding down)
* Multiply the rounded fee by the collateral quantums amount (rounding up)

The precision limit is used in order to match what core does, and (more importantly) to make it easier to implement the formula the same way across languages.