### PR TITLE
v0.8.0 Update signed expiration representation

### DIFF
--- a/__tests__/signable/conditional-transfer.test.ts
+++ b/__tests__/signable/conditional-transfer.test.ts
@@ -30,8 +30,8 @@ const mockParams: ConditionalTransferParams = {
   condition: Buffer.from('mock-condition'),
 };
 const mockSignature = (
-  '014dedad7bd42da36e81ce627e55be508a4afe019700dd478ea8134b3549d327' +
-  '0571d1dcbab6f25f4d2f3af054f359773289266c69df91c9608882f0a9b201d8'
+  '067e90143a21d8a6aca85207de5e124e9644f7adc18deb42c5cf1240766e57bb' +
+  '04a39c4fdadf214d7282a59d37b21e0d3ea7fe1fc0d0ee25c22a3dd9d5cb8307'
 );
 
 describe('SignableConditionalTransfer', () => {
@@ -90,11 +90,12 @@ describe('SignableConditionalTransfer', () => {
 
   describe('toStarkware()', () => {
 
-    it('converts human amounts to quantum amounts', () => {
+    it('converts human amounts to quantum amounts and converts expiration to hours', () => {
       const starkwareConditionalTransfer: StarkwareConditionalTransfer = (
         new SignableConditionalTransfer(mockParams).toStarkware()
       );
       expect(starkwareConditionalTransfer.quantumsAmount).toEqual('49478023');
+      expect(starkwareConditionalTransfer.expirationEpochHours).toBe(444533);
     });
   });
 

--- a/__tests__/signable/order.test.ts
+++ b/__tests__/signable/order.test.ts
@@ -41,12 +41,12 @@ const mockOrder: OrderWithClientId = {
   clientId: 'This is an ID that the client came up with to describe this order',
 };
 const mockSignature = (
-  '059487ea7c537f34516f4dc7c54ad30ab0096823269ba18aea0e64e13fb03462' +
-  '03be73ed4dafbf99baeeaee6dce315cd834b5e3257d4e74371d14cf8f2189a59'
+  '0398287472161cba0e6386ff0b2f25f39ba37c646b7bbadace80eee6b8e7157d' +
+  '01ba924272e1e42b3211b96bbbe012e7e8101e1b3e5b83ea90d161ad11fcced4'
 );
 const mockSignatureEvenY = (
-  '030644ef5b2de9e93f13df5a4cf8284e7256223366b5da29bf2002ed40825171' +
-  '03961ec47c34c49e97095c546895cc22afa6e563474615729720fd8b768c5b87'
+  '05cf391a69386f53693344bada2e0d245879f3c6a98971498b2862ff2f359c49' +
+  '0737deea7e201eaa86c8d6eeb2c1ca3ce89ac248b3fe1a6182301aa72d6e8e4f'
 );
 
 describe('SignableOrder', () => {
@@ -168,13 +168,16 @@ describe('SignableOrder', () => {
 
   describe('toStarkware()', () => {
 
-    it('converts human amounts to quantum amounts', () => {
+    it('converts human amounts to quantum amounts and converts expiration to hours', () => {
       const starkwareOrder: StarkwareOrder = SignableOrder
         .fromOrder(mockOrder)
         .toStarkware();
-      expect(starkwareOrder.quantumsAmountSynthetic).toEqual('14500050000');
-      expect(starkwareOrder.quantumsAmountCollateral).toEqual('50750272151');
-      expect(starkwareOrder.quantumsAmountFee).toEqual('6343784019');
+      expect(starkwareOrder.quantumsAmountSynthetic).toBe('14500050000');
+      expect(starkwareOrder.quantumsAmountCollateral).toBe('50750272151');
+      expect(starkwareOrder.quantumsAmountFee).toBe('6343784019');
+
+      // Order expiration should be rounded up, and should have a buffer added.
+      expect(starkwareOrder.expirationEpochHours).toBe(444581);
     });
 
     it('throws if the market is unknown', () => {

--- a/__tests__/signable/withdrawal.test.ts
+++ b/__tests__/signable/withdrawal.test.ts
@@ -29,8 +29,8 @@ const mockWithdrawal: WithdrawalWithClientId = {
   clientId: 'This is an ID that the client came up with to describe this withdrawal',
 };
 const mockSignature = (
-  '0214a0ab2f3c065c5848ad9dbac6cc98509b66e76a8f563d5c8ffda01b0fa2e0' +
-  '07242b1c65d039fe645d122ecea7c3e58c8fda5814e0c152dbdeef4af706ad06'
+  '05e48c33f8205a5359c95f1bd7385c1c1f587e338a514298c07634c0b6c952ba' +
+  '0687d6980502a5d7fa84ef6fdc00104db22c43c7fb83e88ca84f19faa9ee3de1'
 );
 
 describe('SignableWithdrawal', () => {
@@ -111,11 +111,12 @@ describe('SignableWithdrawal', () => {
 
   describe('toStarkware()', () => {
 
-    it('converts human amounts to quantum amounts', () => {
+    it('converts human amounts to quantum amounts and converts expiration to hours', () => {
       const starkwareWithdrawal: StarkwareWithdrawal = SignableWithdrawal
         .fromWithdrawal(mockWithdrawal)
         .toStarkware();
-      expect(starkwareWithdrawal.quantumsAmount).toEqual('49478023');
+      expect(starkwareWithdrawal.quantumsAmount).toBe('49478023');
+      expect(starkwareWithdrawal.expirationEpochHours).toBe(444533);
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -7,9 +7,14 @@ import nodeCrypto from 'crypto';
 import BN from 'bn.js';
 
 import { hexToBn } from '../lib/util';
-import { ORDER_FIELD_BIT_LENGTHS } from '../signable/constants';
+import {
+  ORDER_FIELD_BIT_LENGTHS,
+  STARK_SIGNATURE_EXPIRATION_BUFFER_HOURS,
+} from '../signable/constants';
 
 const MAX_NONCE = new BN(2).pow(new BN(ORDER_FIELD_BIT_LENGTHS.nonce));
+const ONE_SECOND_MS = 1000;
+const ONE_HOUR_MS = 60 * 60 * ONE_SECOND_MS;
 
 /**
  * Generate a nonce deterministically from an arbitrary string provided by a client.
@@ -19,6 +24,23 @@ export function nonceFromClientId(clientId: string): string {
   return hexToBn(nonceHex).mod(MAX_NONCE).toString();
 }
 
-export function isoTimestampToEpochSeconds(isoTimestamp: string): string {
-  return `${Math.floor(new Date(isoTimestamp).getTime() / 1000)}`;
+/**
+ * Convert an ISO timestamp to an epoch timestamp in seconds, rounding down.
+ */
+export function isoTimestampToEpochSeconds(isoTimestamp: string): number {
+  return Math.floor(new Date(isoTimestamp).getTime() / ONE_SECOND_MS);
+}
+
+/**
+ * Convert an ISO timestamp to an epoch timestamp in hours, rounding up.
+ */
+export function isoTimestampToEpochHours(isoTimestamp: string): number {
+  return Math.ceil(new Date(isoTimestamp).getTime() / ONE_HOUR_MS);
+}
+
+/**
+ * Add expiration buffer to ensure an order signature is valid when it arrives on-chain.
+ */
+export function addOrderExpirationBufferHours(expirationEpochHours: number): number {
+  return expirationEpochHours + STARK_SIGNATURE_EXPIRATION_BUFFER_HOURS;
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -70,6 +70,16 @@ export function decToBn(dec: string): BN {
 }
 
 /**
+ * Convert an integer number to a BN.
+ */
+export function intToBn(int: number): BN {
+  if (!Number.isInteger(int)) {
+    throw new Error('intToBn: Input is not an integer');
+  }
+  return new BN(int);
+}
+
+/**
  * Convert a string to a BN equal to the left-aligned UTF-8 representation with a fixed bit length.
  *
  * The specified numBits is expected to be a multiple of four.

--- a/src/signable/conditional-transfer.ts
+++ b/src/signable/conditional-transfer.ts
@@ -5,7 +5,7 @@ import {
   COLLATERAL_ASSET_ID,
 } from '../constants';
 import {
-  isoTimestampToEpochSeconds,
+  isoTimestampToEpochHours,
   nonceFromClientId,
   toQuantumsExact,
 } from '../helpers';
@@ -14,6 +14,7 @@ import {
   bufferToBn,
   decToBn,
   hexToBn,
+  intToBn,
 } from '../lib/util';
 import {
   ConditionalTransferParams,
@@ -43,8 +44,8 @@ export class SignableConditionalTransfer extends StarkSignable<StarkwareConditio
     // The transfer asset is always the collateral asset.
     const quantumsAmount = toQuantumsExact(transfer.humanAmount, COLLATERAL_ASSET);
 
-    // Convert to a Unix timestamp (in seconds).
-    const expirationEpochSeconds = isoTimestampToEpochSeconds(transfer.expirationIsoTimestamp);
+    // Convert to a Unix timestamp (in hours).
+    const expirationEpochHours = isoTimestampToEpochHours(transfer.expirationIsoTimestamp);
 
     super({
       senderPositionId: transfer.senderPositionId,
@@ -53,7 +54,7 @@ export class SignableConditionalTransfer extends StarkSignable<StarkwareConditio
       condition: transfer.condition,
       quantumsAmount,
       nonce,
-      expirationEpochSeconds,
+      expirationEpochHours,
     });
   }
 
@@ -64,7 +65,7 @@ export class SignableConditionalTransfer extends StarkSignable<StarkwareConditio
     const conditionBn = bufferToBn(this.message.condition);
     const quantumsAmountBn = decToBn(this.message.quantumsAmount);
     const nonceBn = decToBn(this.message.nonce);
-    const expirationEpochSecondsBn = decToBn(this.message.expirationEpochSeconds);
+    const expirationEpochSecondsBn = intToBn(this.message.expirationEpochHours);
 
     if (senderPositionIdBn.bitLength() > CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.positionId) {
       throw new Error('SignableOraclePrice: senderPositionId exceeds max value');
@@ -90,9 +91,9 @@ export class SignableConditionalTransfer extends StarkSignable<StarkwareConditio
     }
     if (
       expirationEpochSecondsBn.bitLength() >
-      CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.expirationEpochSeconds
+      CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.expirationEpochHours
     ) {
-      throw new Error('SignableOraclePrice: expirationEpochSeconds exceeds max value');
+      throw new Error('SignableOraclePrice: expirationEpochHours exceeds max value');
     }
 
     // The transfer asset and fee asset are always the collateral asset.
@@ -113,7 +114,7 @@ export class SignableConditionalTransfer extends StarkSignable<StarkwareConditio
     const transferPart3 = new BN(CONDITIONAL_TRANSFER_PREFIX)
       .iushln(CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.quantumsAmount).iadd(quantumsAmountBn)
       .iushln(CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.quantumsAmount).iadd(MAX_AMOUNT_FEE_BN)
-      .iushln(CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.expirationEpochSeconds).iadd(
+      .iushln(CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS.expirationEpochHours).iadd(
         expirationEpochSecondsBn,
       )
       .iushln(CONDITIONAL_TRANSFER_PADDING_BITS);

--- a/src/signable/constants.ts
+++ b/src/signable/constants.ts
@@ -1,3 +1,5 @@
+export const STARK_SIGNATURE_EXPIRATION_BUFFER_HOURS = 24 * 2; // Two days.
+
 export const ORDER_FIELD_BIT_LENGTHS = {
   assetIdSynthetic: 128,
   assetIdCollateral: 250,
@@ -5,7 +7,7 @@ export const ORDER_FIELD_BIT_LENGTHS = {
   quantumsAmount: 64,
   nonce: 32,
   positionId: 64,
-  expirationEpochSeconds: 32,
+  expirationEpochHours: 32,
 };
 
 export const WITHDRAWAL_FIELD_BIT_LENGTHS = {
@@ -13,7 +15,7 @@ export const WITHDRAWAL_FIELD_BIT_LENGTHS = {
   positionId: 64,
   nonce: 32,
   quantumsAmount: 64,
-  expirationEpochSeconds: 32,
+  expirationEpochHours: 32,
 };
 
 export const CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS = {
@@ -22,7 +24,7 @@ export const CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS = {
   positionId: 64,
   nonce: 32,
   quantumsAmount: 64,
-  expirationEpochSeconds: 32,
+  expirationEpochHours: 32,
   condition: 251,
 };
 

--- a/src/signable/oracle-price.ts
+++ b/src/signable/oracle-price.ts
@@ -2,7 +2,12 @@ import BN from 'bn.js';
 
 import { isoTimestampToEpochSeconds } from '../helpers';
 import { pedersen } from '../lib/starkex-resources/crypto';
-import { decToBn, hexToBn, utf8ToBn } from '../lib/util';
+import {
+  decToBn,
+  hexToBn,
+  intToBn,
+  utf8ToBn,
+} from '../lib/util';
 import {
   OraclePriceWithAssetName,
   OraclePriceWithAssetId,
@@ -42,7 +47,7 @@ export class SignableOraclePrice extends StarkSignable<OraclePriceWithAssetId> {
 
   protected calculateHash(): BN {
     const priceBn = decToBn(this.message.price);
-    const timestampEpochSecondsBn = decToBn(isoTimestampToEpochSeconds(this.message.isoTimestamp));
+    const timestampEpochSecondsBn = intToBn(isoTimestampToEpochSeconds(this.message.isoTimestamp));
     const signedAssetId = hexToBn(this.message.signedAssetId);
 
     if (priceBn.bitLength() > ORACLE_PRICE_FIELD_BIT_LENGTHS.price) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export interface StarkwareWithdrawal {
   positionId: string;
   quantumsAmount: string;
   nonce: string; // For signature. A base-10 integer.
-  expirationEpochSeconds: string;
+  expirationEpochHours: number;
 }
 
 // ============ Conditional Transfer Parameters ============
@@ -77,7 +77,7 @@ export interface StarkwareConditionalTransfer {
   condition: Buffer;
   quantumsAmount: string;
   nonce: string; // For signature. A base-10 integer.
-  expirationEpochSeconds: string;
+  expirationEpochHours: number;
 }
 
 // ============ Order Parameters ============
@@ -120,7 +120,7 @@ export interface StarkwareOrder extends StarkwareAmounts {
   assetIdFee: string;
   positionId: string;
   nonce: string; // For signature. A base-10 integer.
-  expirationEpochSeconds: string;
+  expirationEpochHours: number;
 }
 
 // ============ API Request Parameters ============


### PR DESCRIPTION
* Add a buffer to order signatures since orders may have a short time-to-live on the orderbook, but we need to ensure their signatures are valid by the time they reach the blockchain.
  * We don't add a buffer to other signatures since we can enforce at the API level that those have a sufficiently long expiration.
* The signed expiration timestamp should be measured in hours, not seconds, and should be rounded up (except for oracle prices, where expirations are in seconds and rounded down).
* (minor) Return expiration as `number` instead of `string` in Starkware representation