### PR TITLE
v0.8.3 Cache common pedersen hashes [BAC-756]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,6 +801,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -964,6 +981,12 @@
       "integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==",
       "dev": true
     },
+    "@types/proxyquire": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+      "integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
+      "dev": true
+    },
     "@types/secp256k1": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
@@ -971,6 +994,21 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.10.tgz",
+      "integrity": "sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.0",
@@ -3183,6 +3221,16 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4033,6 +4081,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-path-inside": {
@@ -4938,6 +4992,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "keccak": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
@@ -5039,6 +5099,12 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5125,6 +5191,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -5464,6 +5536,12 @@
         }
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5506,6 +5584,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-addon-api": {
       "version": "2.0.2",
@@ -6040,6 +6131,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -6147,6 +6255,17 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "psl": {
@@ -6784,6 +6903,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,12 @@
   },
   "devDependencies": {
     "@dydxprotocol/node-service-base-dev": "0.0.11",
+    "@types/proxyquire": "^1.3.28",
+    "@types/sinon": "^9.0.10",
     "expect": "^26.6.2",
     "mocha": "^8.2.1",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^9.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/lib/starkex-resources/crypto.ts
+++ b/src/lib/starkex-resources/crypto.ts
@@ -66,7 +66,7 @@ export function pedersen(
   for (let i = 0; i < input.length; i++) {
     let x: BN = input[i];
     if (!(x.gte(zeroBn) && x.lt(prime))) {
-      throw new Error(`Invalid input to pedersen hash: ${x}`);
+      throw new Error(`Input to pedersen hash out of range: ${x.toString(16)}`);
     }
     for (let j = 0; j < 252; j++) {
       const pt = constantPoints[2 + i * 252 + j];

--- a/src/signable/conditional-transfer.ts
+++ b/src/signable/conditional-transfer.ts
@@ -21,6 +21,7 @@ import {
   StarkwareConditionalTransfer,
 } from '../types';
 import { CONDITIONAL_TRANSFER_FIELD_BIT_LENGTHS } from './constants';
+import { getCacheableHash } from './hashes';
 import { StarkSignable } from './stark-signable';
 
 // Note: Fees are not supported for conditional transfers.
@@ -98,7 +99,7 @@ export class SignableConditionalTransfer extends StarkSignable<StarkwareConditio
 
     // The transfer asset and fee asset are always the collateral asset.
     // Fees are not supported for conditional transfers.
-    const assetIds = pedersen(COLLATERAL_ASSET_ID_BN, COLLATERAL_ASSET_ID_BN);
+    const assetIds = getCacheableHash(COLLATERAL_ASSET_ID_BN, COLLATERAL_ASSET_ID_BN);
 
     const transferPart1 = pedersen(
       pedersen(

--- a/src/signable/hashes.ts
+++ b/src/signable/hashes.ts
@@ -1,0 +1,58 @@
+/**
+ * Helpers related to pedersen hashes.
+ */
+
+import BN from 'bn.js';
+
+import {
+  ASSET_ID_MAP,
+  COLLATERAL_ASSET,
+  COLLATERAL_ASSET_ID,
+} from '../constants';
+import { pedersen } from '../lib/starkex-resources';
+import { hexToBn } from '../lib/util';
+import { DydxAsset } from '../types';
+
+const CACHE: Record<string, Record<string, BN>> = {};
+
+/**
+ * Get a hash with commonly used parameters. The hash will be cached.
+ */
+export function getCacheableHash(
+  left: BN,
+  right: BN,
+): BN {
+  const leftString = left.toString(16);
+  const rightString = right.toString(16);
+  if (!CACHE[leftString]) {
+    CACHE[leftString] = {};
+  }
+  if (!CACHE[leftString][rightString]) {
+    CACHE[leftString][rightString] = pedersen(left, right);
+  }
+  return CACHE[leftString][rightString];
+}
+
+/**
+ * Pre-compute commonly used hashes.
+ *
+ * This function may take a while to run.
+ */
+export function preComputeHashes(): void {
+  const collateralAssetBn = hexToBn(COLLATERAL_ASSET_ID);
+
+  // orders: hash(hash(sell asset, buy asset), fee asset)
+  Object.values(DydxAsset).forEach((baseAsset) => {
+    if (baseAsset === COLLATERAL_ASSET) {
+      return;
+    }
+    const baseAssetBn = hexToBn(ASSET_ID_MAP[baseAsset]);
+    const buyHash = getCacheableHash(collateralAssetBn, baseAssetBn);
+    const sellHash = getCacheableHash(baseAssetBn, collateralAssetBn);
+    getCacheableHash(buyHash, collateralAssetBn);
+    getCacheableHash(sellHash, collateralAssetBn);
+  });
+
+  // conditional transfers: hash(transfer asset, fee asset)
+  getCacheableHash(collateralAssetBn, collateralAssetBn);
+}

--- a/src/signable/index.ts
+++ b/src/signable/index.ts
@@ -1,4 +1,5 @@
 export { SignableApiRequest } from './api-request';
+export { preComputeHashes } from './hashes';
 export { SignableOraclePrice } from './oracle-price';
 export { SignableOrder } from './order';
 export { SignableWithdrawal } from './withdrawal';

--- a/src/signable/order.ts
+++ b/src/signable/order.ts
@@ -28,6 +28,7 @@ import {
 import {
   ORDER_FIELD_BIT_LENGTHS,
 } from './constants';
+import { getCacheableHash } from './hashes';
 import { StarkSignable } from './stark-signable';
 
 const LIMIT_ORDER_WITH_FEES = 3;
@@ -153,7 +154,7 @@ export class SignableOrder extends StarkSignable<StarkwareOrder> {
       .iushln(ORDER_FIELD_BIT_LENGTHS.expirationEpochHours).iadd(expirationEpochHours)
       .iushln(ORDER_PADDING_BITS);
 
-    const assetsBn = pedersen(pedersen(assetIdSellBn, assetIdBuyBn), assetIdFeeBn);
+    const assetsBn = getCacheableHash(getCacheableHash(assetIdSellBn, assetIdBuyBn), assetIdFeeBn);
     return pedersen(pedersen(assetsBn, orderPart1), orderPart2);
   }
 


### PR DESCRIPTION
`preComputeHashes()` can be called on startup to pre-compute common hashes for all markets.