### PR TITLE
v0.9.1 Add function to hash in worker thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/signable/hash-in-worker-thread.ts
+++ b/src/signable/hash-in-worker-thread.ts
@@ -1,0 +1,47 @@
+import {
+  Worker,
+  isMainThread,
+  parentPort,
+  workerData,
+} from 'worker_threads';
+
+import BN from 'bn.js';
+
+import { pedersen } from '../lib/starkex-resources';
+import { HashFunction } from '../types';
+
+let hashFunction: HashFunction = function hashInWorkerThread(_a: BN, _b: BN) {
+  throw new Error('Expected hashInWorkerThread() to be called from the main thread');
+};
+
+if (isMainThread) {
+  /**
+   * Pedersen hash implementation that runs in a worker thread.
+   */
+  hashFunction = function hashInWorkerThread(a: BN, b: BN): Promise<BN> {
+    return new Promise((resolve, reject) => {
+      const worker = new Worker(
+        __filename, {
+          workerData: {
+            a: a.toString(),
+            b: b.toString(),
+          },
+        },
+      );
+      worker.on('message', (hashResult) => {
+        resolve(new BN(hashResult));
+      });
+      worker.on('error', reject);
+      worker.on('exit', (code) => {
+        if (code !== 0) {
+          reject(new Error(`Worker stopped with exit code ${code}`));
+        }
+      });
+    });
+  };
+} else {
+  const { a, b }: { a: string, b: string } = workerData;
+  const hashResult = pedersen(new BN(a), new BN(b)).toString();
+  parentPort!.postMessage(hashResult);
+}
+export const hashInWorkerThread = hashFunction;

--- a/src/signable/index.ts
+++ b/src/signable/index.ts
@@ -1,4 +1,5 @@
 export { SignableApiRequest } from './api-request';
+export { hashInWorkerThread } from './hash-in-worker-thread';
 export {
   preComputeHashes,
   setGlobalStarkHashImplementation,


### PR DESCRIPTION
Usage:

```typescript
await setGlobalStarkHashImplementation(hashInWorkerThread);
await preComputeHashes(); // Optional, but recommended.
```

Available as of node `v10.5.0`, though below `11.7.0` needs `--experimental-worker` flag.