### PR TITLE
v0.11.0 Change the interface for signing oracle prices

### DIFF
--- a/__tests__/signable/oracle-price.test.ts
+++ b/__tests__/signable/oracle-price.test.ts
@@ -8,20 +8,21 @@ import _ from 'lodash';
 import {
   DydxMarket,
   KeyPair,
-  OraclePriceParams,
+  OraclePriceWithMarket,
 } from '../../src/types';
 import { generateKeyPairUnsafe } from '../../src/keys';
 import { mutateHexStringAt } from '../util';
 
 // Module under test.
 import { SignableOraclePrice } from '../../src/signable/oracle-price';
+import { getSignedAssetName } from '../../src';
 
 // Mock params.
 const mockKeyPair: KeyPair = {
   publicKey: '1895a6a77ae14e7987b9cb51329a5adfb17bd8e7c638f92d6892d76e51cebcf',
   privateKey: '178047D3869489C055D7EA54C014FFB834A069C9595186ABE04EA4D1223A03F',
 };
-const mockOraclePrice: OraclePriceParams = {
+const mockOraclePrice: OraclePriceWithMarket = {
   market: DydxMarket.BTC_USD,
   oracleName: 'dYdX',
   humanPrice: '11512.34',
@@ -38,7 +39,7 @@ describe('SignableOraclePrice', () => {
 
     it('returns true for a valid signature', async () => {
       const result = await SignableOraclePrice
-        .fromPrice(mockOraclePrice)
+        .fromPriceWithMarket(mockOraclePrice)
         .verifySignature(mockSignature, mockKeyPair.publicKey);
       expect(result).toBe(true);
     });
@@ -48,7 +49,7 @@ describe('SignableOraclePrice', () => {
       await Promise.all(_.range(1, 4).map(async (i) => {
         const badSignature: string = mutateHexStringAt(mockSignature, i);
         const result = await SignableOraclePrice
-          .fromPrice(mockOraclePrice)
+          .fromPriceWithMarket(mockOraclePrice)
           .verifySignature(badSignature, mockKeyPair.publicKey);
         expect(result).toBe(false);
       }));
@@ -57,7 +58,7 @@ describe('SignableOraclePrice', () => {
       await Promise.all(_.range(1, 4).map(async (i) => {
         const badSignature: string = mutateHexStringAt(mockSignature, i + 64);
         const result = await SignableOraclePrice
-          .fromPrice(mockOraclePrice)
+          .fromPriceWithMarket(mockOraclePrice)
           .verifySignature(badSignature, mockKeyPair.publicKey);
         expect(result).toBe(false);
       }));
@@ -66,53 +67,63 @@ describe('SignableOraclePrice', () => {
 
   describe('sign()', () => {
 
-    it('signs an oracle price', async () => {
+    it('signs an oracle price, with a market', async () => {
       const signature = await SignableOraclePrice
-        .fromPrice(mockOraclePrice)
+        .fromPriceWithMarket(mockOraclePrice)
+        .sign(mockKeyPair.privateKey);
+      expect(signature).toEqual(mockSignature);
+    });
+
+    it('signs an oracle price, with an asset name', async () => {
+      const signature = await SignableOraclePrice
+        .fromPriceWithAssetName({
+          ...mockOraclePrice,
+          assetName: getSignedAssetName(mockOraclePrice.market),
+        })
         .sign(mockKeyPair.privateKey);
       expect(signature).toEqual(mockSignature);
     });
 
     it('generates a different signature when the market is different', async () => {
-      const oraclePrice: OraclePriceParams = {
+      const oraclePrice: OraclePriceWithMarket = {
         ...mockOraclePrice,
         market: DydxMarket.ETH_USD,
       };
       const signature = await SignableOraclePrice
-        .fromPrice(oraclePrice)
+        .fromPriceWithMarket(oraclePrice)
         .sign(mockKeyPair.privateKey);
       expect(signature).not.toEqual(mockSignature);
     });
 
     it('generates a different signature when the oracle name is different', async () => {
-      const oraclePrice: OraclePriceParams = {
+      const oraclePrice: OraclePriceWithMarket = {
         ...mockOraclePrice,
         oracleName: 'Other',
       };
       const signature = await SignableOraclePrice
-        .fromPrice(oraclePrice)
+        .fromPriceWithMarket(oraclePrice)
         .sign(mockKeyPair.privateKey);
       expect(signature).not.toEqual(mockSignature);
     });
 
     it('generates a different signature when the timestamp is different', async () => {
-      const oraclePrice: OraclePriceParams = {
+      const oraclePrice: OraclePriceWithMarket = {
         ...mockOraclePrice,
         isoTimestamp: new Date().toISOString(),
       };
       const signature = await SignableOraclePrice
-        .fromPrice(oraclePrice)
+        .fromPriceWithMarket(oraclePrice)
         .sign(mockKeyPair.privateKey);
       expect(signature).not.toEqual(mockSignature);
     });
 
     it('throws an error if the oracle name is too long', async () => {
-      const oraclePrice: OraclePriceParams = {
+      const oraclePrice: OraclePriceWithMarket = {
         ...mockOraclePrice,
         oracleName: 'Other2',
       };
       expect(
-        () => SignableOraclePrice.fromPrice(oraclePrice),
+        () => SignableOraclePrice.fromPriceWithMarket(oraclePrice),
       ).toThrow('Input does not fit in numBits=40 bits');
     });
   });
@@ -121,7 +132,7 @@ describe('SignableOraclePrice', () => {
     // Repeat some number of times.
     await Promise.all(_.range(3).map(async () => {
       const keyPair: KeyPair = generateKeyPairUnsafe();
-      const signableOraclePrice = SignableOraclePrice.fromPrice(mockOraclePrice);
+      const signableOraclePrice = SignableOraclePrice.fromPriceWithMarket(mockOraclePrice);
       const signature = await signableOraclePrice.sign(keyPair.privateKey);
 
       // Expect to be valid when verifying with the right public key.

--- a/__tests__/signable/oracle-price.test.ts
+++ b/__tests__/signable/oracle-price.test.ts
@@ -27,7 +27,6 @@ const mockOraclePrice: OraclePriceParams = {
   humanPrice: '11512.34',
   isoTimestamp: '2020-01-01T00:00:00.000Z',
 };
-const mockSignedAssetId = '425443555344000000000000000000004d616b6572';
 const mockSignature = (
   '020b64c5ead744a9a39bb20cee8193e15958d2f5bc065a3a31a8245d800907ae' +
   '0043e5681d7fd1e0720cc578e3d076ea29dbfe902f30445da8aa74bd112aa710'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1553,9 +1553,9 @@
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
     "bn.js": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
     },
     "boxen": {
       "version": "4.2.0",
@@ -2390,13 +2390,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        }
       }
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {
@@ -29,7 +29,6 @@
     "@types/elliptic": "^6.4.12",
     "big.js": "6.0.3",
     "bip39": "^3.0.3",
-    "bn.js": "5.1.3",
     "ethereum-cryptography": "^0.1.3",
     "hash.js": "^1.1.7"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/starkex-lib",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Cryptographic functions for use with StarkEx",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,13 +19,6 @@ export const SYNTHETIC_ASSET_MAP: Record<DydxMarket, DydxAsset> = {
   [DydxMarket.LINK_USD]: DydxAsset.LINK,
 };
 
-// Asset signed by oracle price signers.
-export const SIGNED_ASSET_ID_MAP: Record<DydxMarket, string> = {
-  [DydxMarket.BTC_USD]: '0x425443555344000000000000000000004d616b6572',
-  [DydxMarket.ETH_USD]: '0x455448555344000000000000000000004d616b6572',
-  [DydxMarket.LINK_USD]: '0xf2',
-};
-
 /**
  * The smallest unit of the asset in the Starkware system, represented in canonical (human) units.
  */

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -48,15 +48,21 @@ export function addOrderExpirationBufferHours(expirationEpochHours: number): num
 }
 
 /**
+ * Get the asset name to be signed, which is the market name with the hyphen removed.
+ */
+export function getSignedAssetName(
+  market: DydxMarket,
+): string {
+  return market.replace('-', '');
+}
+
+/**
  * Get the asset ID to be signed by a price oracle. It consists of an asset name and oracle name.
- *
- * The asset name to be signed is equal to the market name, with the hyphen removed.
  */
 export function getSignedAssetId(
-  market: DydxMarket,
+  assetName: string,
   oracleName: string,
 ): string {
-  const assetName = market.replace('-', '');
   const assetNameBn = utf8ToBn(assetName, ORACLE_PRICE_FIELD_BIT_LENGTHS.assetName);
   const oracleNameBn = utf8ToBn(oracleName, ORACLE_PRICE_FIELD_BIT_LENGTHS.oracleName);
 

--- a/src/signable/constants.ts
+++ b/src/signable/constants.ts
@@ -1,4 +1,5 @@
 export const STARK_SIGNATURE_EXPIRATION_BUFFER_HOURS = 24 * 2; // Two days.
+export const ORACLE_PRICE_DECIMALS = 18;
 
 export const ORDER_FIELD_BIT_LENGTHS = {
   assetIdSynthetic: 128,

--- a/src/signable/index.ts
+++ b/src/signable/index.ts
@@ -12,6 +12,7 @@ export { SignableOraclePrice } from './oracle-price';
 export { SignableOrder } from './order';
 export { SignableWithdrawal } from './withdrawal';
 export { SignableConditionalTransfer } from './conditional-transfer';
+export { StarkSignable } from './stark-signable';
 
 let maybeHashInWorkerThread: HashFunction = (_a: BN, _b: BN) => {
   throw new Error('Cannot use hashInWorkerThread() since worker_threads is not available');

--- a/src/signable/oracle-price.ts
+++ b/src/signable/oracle-price.ts
@@ -3,6 +3,7 @@ import BN from 'bn.js';
 
 import {
   getSignedAssetId,
+  getSignedAssetName,
   isoTimestampToEpochSeconds,
 } from '../helpers';
 import {
@@ -11,7 +12,8 @@ import {
   intToBn,
 } from '../lib/util';
 import {
-  OraclePriceParams,
+  OraclePriceWithAssetName,
+  OraclePriceWithMarket,
   StarkwareOraclePrice,
 } from '../types';
 import {
@@ -26,11 +28,24 @@ import { StarkSignable } from './stark-signable';
  */
 export class SignableOraclePrice extends StarkSignable<StarkwareOraclePrice> {
 
-  static fromPrice(
-    params: OraclePriceParams,
+  static fromPriceWithMarket(
+    params: OraclePriceWithMarket,
   ): SignableOraclePrice {
     if (typeof params.market !== 'string') {
       throw new Error('SignableOraclePrice.fromPrice: market must be a string');
+    }
+    const assetName = getSignedAssetName(params.market);
+    return SignableOraclePrice.fromPriceWithAssetName({
+      ...params,
+      assetName,
+    });
+  }
+
+  static fromPriceWithAssetName(
+    params: OraclePriceWithAssetName,
+  ): SignableOraclePrice {
+    if (typeof params.assetName !== 'string') {
+      throw new Error('SignableOraclePrice.fromPrice: assetName must be a string');
     }
     if (typeof params.oracleName !== 'string') {
       throw new Error('SignableOraclePrice.fromPrice: oracleName must be a string');
@@ -42,7 +57,7 @@ export class SignableOraclePrice extends StarkSignable<StarkwareOraclePrice> {
       throw new Error('SignableOraclePrice.fromPrice: isoTimestamp must be a string');
     }
 
-    const signedAssetId = getSignedAssetId(params.market, params.oracleName);
+    const signedAssetId = getSignedAssetId(params.assetName, params.oracleName);
 
     const signedPrice = new Big(params.humanPrice);
     signedPrice.e += ORACLE_PRICE_DECIMALS;

--- a/src/signable/oracle-price.ts
+++ b/src/signable/oracle-price.ts
@@ -62,11 +62,17 @@ export class SignableOraclePrice extends StarkSignable<StarkwareOraclePrice> {
     const signedPrice = new Big(params.humanPrice);
     signedPrice.e += ORACLE_PRICE_DECIMALS;
 
+    if (!signedPrice.mod(1).eq(0)) {
+      throw new Error(
+        'SignableOraclePrice.fromPrice: humanPrice can have at most 18 decimals of precision',
+      );
+    }
+
     const expirationEpochSeconds = isoTimestampToEpochSeconds(params.isoTimestamp);
 
     return new SignableOraclePrice({
       signedAssetId,
-      signedPrice: signedPrice.round(RoundingMode.RoundHalfEven).toFixed(0),
+      signedPrice: signedPrice.toFixed(0),
       expirationEpochSeconds,
     });
   }

--- a/src/signable/oracle-price.ts
+++ b/src/signable/oracle-price.ts
@@ -1,4 +1,4 @@
-import Big from 'big.js';
+import Big, { RoundingMode } from 'big.js';
 import BN from 'bn.js';
 
 import {
@@ -47,17 +47,11 @@ export class SignableOraclePrice extends StarkSignable<StarkwareOraclePrice> {
     const signedPrice = new Big(params.humanPrice);
     signedPrice.e += ORACLE_PRICE_DECIMALS;
 
-    if (!signedPrice.mod(1).eq(0)) {
-      throw new Error(
-        'SignableOraclePrice.fromPrice: humanPrice can have at most 18 decimals of precision',
-      );
-    }
-
     const expirationEpochSeconds = isoTimestampToEpochSeconds(params.isoTimestamp);
 
     return new SignableOraclePrice({
       signedAssetId,
-      signedPrice: signedPrice.toFixed(0),
+      signedPrice: signedPrice.round(RoundingMode.RoundHalfEven).toFixed(0),
       expirationEpochSeconds,
     });
   }

--- a/src/signable/oracle-price.ts
+++ b/src/signable/oracle-price.ts
@@ -1,4 +1,4 @@
-import Big, { RoundingMode } from 'big.js';
+import Big from 'big.js';
 import BN from 'bn.js';
 
 import {

--- a/src/signable/oracle-price.ts
+++ b/src/signable/oracle-price.ts
@@ -1,53 +1,70 @@
+import Big from 'big.js';
 import BN from 'bn.js';
 
-import { isoTimestampToEpochSeconds } from '../helpers';
+import {
+  getSignedAssetId,
+  isoTimestampToEpochSeconds,
+} from '../helpers';
 import {
   decToBn,
   hexToBn,
   intToBn,
-  utf8ToBn,
 } from '../lib/util';
 import {
-  OraclePriceWithAssetName,
-  OraclePriceWithAssetId,
+  OraclePriceParams,
+  StarkwareOraclePrice,
 } from '../types';
-import { ORACLE_PRICE_FIELD_BIT_LENGTHS } from './constants';
+import {
+  ORACLE_PRICE_DECIMALS,
+  ORACLE_PRICE_FIELD_BIT_LENGTHS,
+} from './constants';
 import { getPedersenHash } from './hashes';
 import { StarkSignable } from './stark-signable';
 
 /**
  * Wrapper object to hash, sign, and verify an oracle price.
  */
-export class SignableOraclePrice extends StarkSignable<OraclePriceWithAssetId> {
+export class SignableOraclePrice extends StarkSignable<StarkwareOraclePrice> {
 
-  static fromPrice = SignableOraclePrice.fromPriceWithAssetName; // Alias.
-
-  static fromPriceWithAssetName(
-    params: OraclePriceWithAssetName,
+  static fromPrice(
+    params: OraclePriceParams,
   ): SignableOraclePrice {
-    const assetNameBn = utf8ToBn(params.assetName, ORACLE_PRICE_FIELD_BIT_LENGTHS.assetName);
-    const oracleNameBn = utf8ToBn(params.oracleName, ORACLE_PRICE_FIELD_BIT_LENGTHS.oracleName);
+    if (typeof params.market !== 'string') {
+      throw new Error('SignableOraclePrice.fromPrice: market must be a string');
+    }
+    if (typeof params.oracleName !== 'string') {
+      throw new Error('SignableOraclePrice.fromPrice: oracleName must be a string');
+    }
+    if (typeof params.humanPrice !== 'string') {
+      throw new Error('SignableOraclePrice.fromPrice: humanPrice must be a string');
+    }
+    if (typeof params.isoTimestamp !== 'string') {
+      throw new Error('SignableOraclePrice.fromPrice: isoTimestamp must be a string');
+    }
 
-    const signedAssetId = assetNameBn
-      .iushln(ORACLE_PRICE_FIELD_BIT_LENGTHS.oracleName)
-      .iadd(oracleNameBn);
+    const signedAssetId = getSignedAssetId(params.market, params.oracleName);
+
+    const signedPrice = new Big(params.humanPrice);
+    signedPrice.e += ORACLE_PRICE_DECIMALS;
+
+    if (!signedPrice.mod(1).eq(0)) {
+      throw new Error(
+        'SignableOraclePrice.fromPrice: humanPrice can have at most 18 decimals of precision',
+      );
+    }
+
+    const expirationEpochSeconds = isoTimestampToEpochSeconds(params.isoTimestamp);
 
     return new SignableOraclePrice({
-      signedAssetId: signedAssetId.toString(16),
-      price: params.price,
-      isoTimestamp: params.isoTimestamp,
+      signedAssetId,
+      signedPrice: signedPrice.toFixed(0),
+      expirationEpochSeconds,
     });
   }
 
-  static fromPriceWithAssetId(
-    params: OraclePriceWithAssetId,
-  ): SignableOraclePrice {
-    return new SignableOraclePrice(params);
-  }
-
   protected async calculateHash(): Promise<BN> {
-    const priceBn = decToBn(this.message.price);
-    const timestampEpochSecondsBn = intToBn(isoTimestampToEpochSeconds(this.message.isoTimestamp));
+    const priceBn = decToBn(this.message.signedPrice);
+    const timestampEpochSecondsBn = intToBn(this.message.expirationEpochSeconds);
     const signedAssetId = hexToBn(this.message.signedAssetId);
 
     if (priceBn.bitLength() > ORACLE_PRICE_FIELD_BIT_LENGTHS.price) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,14 @@ export interface ApiRequestParams {
 
 // ============ Oracle Price Parameters ============
 
-export interface OraclePriceParams {
+export interface OraclePriceWithAssetName {
+  assetName: string;
+  oracleName: string;
+  humanPrice: string;
+  isoTimestamp: string;
+}
+
+export interface OraclePriceWithMarket {
   market: DydxMarket;
   oracleName: string;
   humanPrice: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,16 +151,16 @@ export interface ApiRequestParams {
 
 // ============ Oracle Price Parameters ============
 
-export interface OraclePriceWithAssetName {
-  assetName: string;
+export interface OraclePriceParams {
+  market: DydxMarket;
   oracleName: string;
-  price: string;
+  humanPrice: string;
   isoTimestamp: string;
 }
 
-export interface OraclePriceWithAssetId {
+export interface StarkwareOraclePrice {
   // Note: This ID is specific to oracle signing and differs from the normal Starkware asset ID.
   signedAssetId: string;
-  price: string;
-  isoTimestamp: string;
+  signedPrice: string; // Fixed point with 18 decimals.
+  expirationEpochSeconds: number;
 }


### PR DESCRIPTION
Two breaking changes:
* require a market or asset name (instead of an asset ID or asset name)
* require a human-readable price (automatically rounded to 18 decimals places with RoundHalfEven)